### PR TITLE
Add patch for skipping camera interpolation during non-gameplay segments.

### DIFF
--- a/patches/particle_transform_tagging.c
+++ b/patches/particle_transform_tagging.c
@@ -132,7 +132,7 @@ RECOMP_PATCH void __particleEmitter_drawOnPass(ParticleEmitter *this, Gfx **gfx,
             func_80344C2C(this->unk0_16);
             // @recomp Get the particle's ID and use it to set a matrix group for this particle.
             u32 transform_id = NORMAL_PARTICLE_TRANSFORM_ID_START + get_particle_id(iPtr);
-            gEXMatrixGroupDecomposedNormal((*gfx)++, transform_id, G_EX_PUSH, G_MTX_MODELVIEW, G_EX_EDIT_ALLOW);
+            gEXMatrixGroupDecomposedNormal((*gfx)++, transform_id, G_EX_PUSH, G_MTX_MODELVIEW, G_EX_EDIT_NONE);
 
             if(this->draw_mode & PART_EMIT_ROTATABLE){
                 func_80344720(this->unk34, (s32)iPtr->frame, 0, position, flat_rotation, scale, gfx, mtx);

--- a/patches/patches.h
+++ b/patches/patches.h
@@ -50,6 +50,9 @@ void osWriteBackDCacheAll(void);
     )
 #endif
 
+#define gEXMatrixGroupSkipAll(cmd, id, push, proj, edit) \
+    gEXMatrixGroup(cmd, id, G_EX_INTERPOLATE_SIMPLE, push, proj, G_EX_COMPONENT_SKIP, G_EX_COMPONENT_SKIP, G_EX_COMPONENT_SKIP, G_EX_COMPONENT_SKIP, G_EX_COMPONENT_SKIP, G_EX_COMPONENT_SKIP, G_EX_COMPONENT_SKIP, G_EX_ORDER_LINEAR, edit, G_EX_ASPECT_AUTO, G_EX_COMPONENT_SKIP, G_EX_COMPONENT_SKIP)
+
 #define gEXMatrixGroupSimpleNormal(cmd, id, push, proj, edit) \
     gEXMatrixGroup(cmd, id, G_EX_INTERPOLATE_SIMPLE, push, proj, G_EX_COMPONENT_INTERPOLATE, G_EX_COMPONENT_INTERPOLATE, G_EX_COMPONENT_INTERPOLATE, G_EX_COMPONENT_INTERPOLATE, G_EX_COMPONENT_INTERPOLATE, G_EX_COMPONENT_SKIP, G_EX_COMPONENT_INTERPOLATE, G_EX_ORDER_LINEAR, edit, G_EX_ASPECT_AUTO, G_EX_COMPONENT_SKIP, G_EX_COMPONENT_AUTO)
     
@@ -82,5 +85,6 @@ void set_additional_model_scale(f32 x, f32 y, f32 z);
 void set_frustum_checks_enabled(int enabled);
 void set_all_interpolation_skipped(bool skipped);
 bool all_interpolation_skipped();
+bool perspective_interpolation_skipped();
 
 #endif

--- a/patches/projection_transform_tagging.c
+++ b/patches/projection_transform_tagging.c
@@ -291,14 +291,17 @@ RECOMP_PATCH void func_803163A8(GcZoombox *this, Gfx **gfx, Mtx **mtx) {
         anctrl_drawSetup(this->anim_ctrl, sp50, 1);
     }
 
-    // @recomp Set the model transform ID.
+    // @recomp Set the model transform ID. Skip interpolation when the camera does a cut.
     u32 prev_transform_id = cur_drawn_model_transform_id;
+    s32 prev_skip = cur_drawn_model_transform_id_skip_interpolation;
     cur_drawn_model_transform_id = ZOOMBOX_TRANSFORM_ID_START + this->portrait_id;
+    cur_drawn_model_transform_id_skip_interpolation = perspective_interpolation_skipped();
 
     modelRender_draw(gfx, mtx, sp50, sp5C, this->unk198 * sp34, sp38, this->model);
 
     // @recomp Reset the model transform ID.
     cur_drawn_model_transform_id = prev_transform_id;
+    cur_drawn_model_transform_id_skip_interpolation = prev_skip;
 }
 
 // @recomp Patched to set the zoombox portrait's model and ortho projection transform IDs.

--- a/patches/prop_transform_tagging.c
+++ b/patches/prop_transform_tagging.c
@@ -92,12 +92,16 @@ RECOMP_PATCH void func_8032D510(Cube *cube, Gfx **gfx, Mtx **mtx, Vtx **vtx){
                     // @recomp Set the matrix group before drawing the sprite.
                     // Skip interpolation on vertices to account for vertex lists changing between frames of the sprite.
                     // Also skip interpolation on scale to account for the scale inverting when sprites are mirrored.
-                    // TODO track this matrix for skipping interpolation when camera interpolation is skipped.
-                    gEXMatrixGroupDecomposed((*gfx)++, base_transform_id, G_EX_PUSH, G_MTX_MODELVIEW,
-                        G_EX_COMPONENT_INTERPOLATE, G_EX_COMPONENT_INTERPOLATE, G_EX_COMPONENT_SKIP, G_EX_COMPONENT_INTERPOLATE,
-                        G_EX_COMPONENT_INTERPOLATE, G_EX_COMPONENT_SKIP, G_EX_COMPONENT_INTERPOLATE,
-                        G_EX_ORDER_LINEAR, G_EX_EDIT_ALLOW, G_EX_COMPONENT_SKIP, G_EX_COMPONENT_AUTO);
-
+                    if (perspective_interpolation_skipped()) {
+                        gEXMatrixGroupSkipAll((*gfx)++, base_transform_id, G_EX_PUSH, G_MTX_MODELVIEW, G_EX_EDIT_NONE);
+                    }
+                    else {
+                        gEXMatrixGroupDecomposed((*gfx)++, base_transform_id, G_EX_PUSH, G_MTX_MODELVIEW,
+                            G_EX_COMPONENT_INTERPOLATE, G_EX_COMPONENT_INTERPOLATE, G_EX_COMPONENT_SKIP, G_EX_COMPONENT_INTERPOLATE,
+                            G_EX_COMPONENT_INTERPOLATE, G_EX_COMPONENT_SKIP, G_EX_COMPONENT_INTERPOLATE,
+                            G_EX_ORDER_LINEAR, G_EX_EDIT_NONE, G_EX_COMPONENT_SKIP, G_EX_COMPONENT_AUTO);
+                    }
+                    
                     // @recomp Also set the model render transform ID before drawing the sprite. This won't have any effect
                     // in the unmodified game, but will allow transform tagging for mods that draw models in place of sprites.
                     cur_drawn_model_transform_id = base_transform_id;

--- a/patches/snow_patches.c
+++ b/patches/snow_patches.c
@@ -198,12 +198,13 @@ RECOMP_PATCH bool func_802F989C(Gfx **gfx, Mtx **mtx, f32 arg2[3]) {
         // @recomp Set a matrix group before drawing the snow particle. If the interpolation skip bit is enabled as the snow particle was just
         // created, do not interpolate and clear the bit instead.
         s32 snowIndex = (struct struct_4D_s *)(arg2)-D_80369280->unk1C;
+        u32 snowId = SNOW_TRANSFORM_ID_START + snowIDArray[snowIndex];
         if (snowIDArray[snowIndex] & SNOW_SKIP_INTERPOLATION_MASK) {
-            gEXMatrixGroupNoInterpolate((*gfx)++, G_EX_PUSH, G_MTX_MODELVIEW, G_EX_EDIT_NONE);
+            gEXMatrixGroupSkipAll((*gfx)++, snowId, G_EX_PUSH, G_MTX_MODELVIEW, G_EX_EDIT_NONE);
             snowIDArray[snowIndex] ^= SNOW_SKIP_INTERPOLATION_MASK;
         }
         else {
-            gEXMatrixGroupSimpleNormal((*gfx)++, SNOW_TRANSFORM_ID_START + snowIDArray[snowIndex], G_EX_PUSH, G_MTX_MODELVIEW, G_EX_EDIT_NONE);
+            gEXMatrixGroupSimpleNormal((*gfx)++, snowId, G_EX_PUSH, G_MTX_MODELVIEW, G_EX_EDIT_NONE);
         }
 
         gSPMatrix((*gfx)++, (*mtx)++, G_MTX_PUSH | G_MTX_LOAD | G_MTX_MODELVIEW);

--- a/patches/transform_ids.h
+++ b/patches/transform_ids.h
@@ -72,6 +72,7 @@ void reset_projection_ids();
 
 extern s32 cur_drawn_model_is_map;
 extern s32 cur_drawn_model_transform_id;
+extern s32 cur_drawn_model_transform_id_skip_interpolation;
 extern s32 cur_perspective_projection_transform_id;
 extern s32 cur_ortho_projection_transform_id;
 


### PR DESCRIPTION
Things that need interpolation skipped as well
- [x] Billboards 
- [x] Skyboxes
- [x] Dialogue Boxes