### PR TITLE
Add a 1 second delay for skipping the intro

### DIFF
--- a/patches/title_screen_patches.c
+++ b/patches/title_screen_patches.c
@@ -21,7 +21,6 @@ extern Struct_core2_9B180_0 D_8036DE00[];
 void func_80322318(Struct_core2_9B180_0*);
 int map_get(void);
 
-
 // @recomp Patched to always allow skipping the intro sequence.
 u8 introFrameCounter = 0;
 RECOMP_PATCH void func_80322490(void) {


### PR DESCRIPTION
Adds a 1 second delay for skipping the intro. This prevents issues with accidentally skipping the intro when navigating the launcher with a controller. 