### PR TITLE
Fix HFR issues with xmas tree

### DIFF
--- a/patches/specific_actor_patches.c
+++ b/patches/specific_actor_patches.c
@@ -102,6 +102,7 @@ RECOMP_PATCH Actor *actor_draw(ActorMarker *marker, Gfx **gfx, Mtx **mtx, Vtx **
     modelRender_preDraw((GenFunction_1)actor_predrawMethod, (s32)this);
     modelRender_postDraw((GenFunction_1)actor_postdrawMethod, (s32)marker);
     modelRender_draw(gfx, mtx, this->position, sp3C, this->scale, (this->unk104 != NULL) ? D_8036E580 : NULL, func_803257B4(marker));
+    // @recomp Re-enable interpolation
     cur_drawn_model_skip_interpolation = FALSE;
     return this;
 }


### PR DESCRIPTION
Disable interpolation on the Christmas tree while the lights turn on, since it causes visual glitches otherwise.