### PR TITLE
Fix Seal Banjo interpolation. Also add exports for model skinning and transform Ids.

### DIFF
--- a/patches/marker_transform_tagging.c
+++ b/patches/marker_transform_tagging.c
@@ -8,14 +8,22 @@ extern s32 D_8036E7B0;
 
 void eggShatter_draw(Gfx **gPtr, Mtx **mPtr, Vtx **vPtr);
 void baModel_draw(Gfx **gfx, Mtx **mtx, Vtx **vtx);
+enum asset_e baModel_getModelId(void);
 void func_8033A28C(bool arg0);
 void func_8033A244(f32);
 void func_8033A280(f32);
+
+ModelSkinningData sPlayerSkinningData;
+
+void bkrecomp_setup_custom_skinning(ModelSkinningData* skinning_data, u32 model_id);
 
 // @recomp Patched to set the current transform ID to banjo's when drawing the player.
 RECOMP_PATCH void player_draw(Gfx **gfx, Mtx **mtx, Vtx **vtx) {
     if (D_8037BFB8) {
         eggShatter_draw(gfx, mtx, vtx);
+
+        // @recomp Set the custom skinning data for Banjo, so CPU-skinning forms such as the seal are interpolated.
+        bkrecomp_setup_custom_skinning(&sPlayerSkinningData, baModel_getModelId());
 
         // @recomp Set the current transform ID to banjo's.
         u32 prev_transform_id = cur_drawn_model_transform_id;

--- a/patches/transform_ids.h
+++ b/patches/transform_ids.h
@@ -4,6 +4,12 @@
 #include "PR/ultratypes.h"
 #include "rt64_extended_gbi.h"
 
+typedef struct {
+    u32 frameCount;
+    u32 modelId;
+    u32 floatStart;
+} ModelSkinningData;
+
 #define MARKER_TRANSFORM_ID_COUNT 256 // Number of transform IDs for each ActorMarker.
 
 // Projections: 0x00001000 - 0x00001FFF

--- a/patches/transform_tagging.c
+++ b/patches/transform_tagging.c
@@ -446,12 +446,6 @@ RECOMP_PATCH void func_80339124(Gfx ** gfx, Mtx ** mtx, BKGeoList *geo_list){
     }while(1);
 }
 
-typedef struct {
-    u32 frameCount;
-    u32 modelId;
-    u32 floatStart;
-} ModelSkinningData;
-
 // @recomp Applies CPU skinning and saves the result to a higher precision vertex buffer.
 #define SKINNING_POSITIONS_MAX 65536
 
@@ -960,4 +954,25 @@ RECOMP_PATCH BKModelBin *modelRender_draw(Gfx **gfx, Mtx **mtx, f32 position[3],
     // @recomp Clear the flag indicating that the model would have been culled before returning.
     cur_model_would_have_been_culled_in_demo = FALSE;
     return model_bin;
+}
+
+RECOMP_EXPORT void bkrecomp_setup_custom_skinning(ModelSkinningData* skinning_data, u32 model_id) {
+    sCurModelSkinningData = skinning_data;
+    sCurModelId = model_id;
+}
+
+RECOMP_EXPORT void bkrecomp_set_drawn_model_transform_id(u32 transform_id) {
+    cur_drawn_model_transform_id = transform_id;
+}
+
+RECOMP_EXPORT s32 bkrecomp_get_drawn_model_transform_id() {
+    return cur_drawn_model_transform_id;
+}
+
+RECOMP_EXPORT void bkrecomp_set_drawn_model_skip_interpolation(u32 skip_interpolation) {
+    cur_drawn_model_skip_interpolation = skip_interpolation;
+}
+
+RECOMP_EXPORT s32 bkrecomp_get_drawn_model_skip_interpolation() {
+    return cur_drawn_model_skip_interpolation;
 }


### PR DESCRIPTION
Fixes https://github.com/BanjoRecomp/BanjoRecomp/issues/115.