### PR TITLE
Use the free function instead of clearing the snow count directly.

### DIFF
--- a/patches/snow_patches.c
+++ b/patches/snow_patches.c
@@ -49,6 +49,7 @@ RECOMP_PATCH void func_802F9054(void) {
     D_80369288 = assetcache_get(0x8a1); //2D_light
 
     // @recomp Initialize the snow ID queue.
+    snowIDQueueCount = 0;
     while (snowIDQueueCount < SNOW_PARTICLE_COUNT_EXPANDED) {
         snowIDQueue[snowIDQueueCount] = snowIDQueueCount;
         snowIDQueueCount++;


### PR DESCRIPTION
Easiest way to validate this fix is to just go to the entrance tunnel while in CCW winter and walk in and out of it. The game despawns the snow and causes the issue because it sets the particle count directly to 0.

Fixes https://github.com/BanjoRecomp/BanjoRecomp/issues/120.