### PR TITLE
add enhancements tab with cutscene skip and classic cheats

### DIFF
--- a/include/banjo_config.h
+++ b/include/banjo_config.h
@@ -1,6 +1,7 @@
 #ifndef __BANJO_CONFIG_H__
 #define __BANJO_CONFIG_H__
 
+#include <cstdint>
 #include <filesystem>
 #include <string>
 #include <string_view>
@@ -28,6 +29,20 @@ namespace banjo {
 
         namespace graphics {
             inline const std::string cutscene_aspect_ratio_mode = "cutscene_aspect_ratio_mode";
+        }
+
+        namespace enhancements {
+            inline const std::string cutscene_skip_mode = "cutscene_skip_mode";
+
+            // Classic Cheats
+            inline const std::string cheat_infinite_health = "cheat_infinite_health";
+            inline const std::string cheat_infinite_lives = "cheat_infinite_lives";
+            inline const std::string cheat_infinite_air = "cheat_infinite_air";
+            inline const std::string cheat_infinite_eggs = "cheat_infinite_eggs";
+            inline const std::string cheat_infinite_red_feathers = "cheat_infinite_red_feathers";
+            inline const std::string cheat_infinite_gold_feathers = "cheat_infinite_gold_feathers";
+            inline const std::string cheat_infinite_mumbo_tokens = "cheat_infinite_mumbo_tokens";
+            inline const std::string cheat_hover = "cheat_hover";
         }
     }
 
@@ -85,6 +100,21 @@ namespace banjo {
     };
 
     CutsceneAspectRatioMode get_cutscene_aspect_ratio_mode();
+
+    enum class CutsceneSkipMode {
+        Off,
+        On,
+        OptionCount
+    };
+
+    NLOHMANN_JSON_SERIALIZE_ENUM(banjo::CutsceneSkipMode, {
+        {banjo::CutsceneSkipMode::Off, "Off"},
+        {banjo::CutsceneSkipMode::On, "On"}
+    });
+
+    CutsceneSkipMode get_cutscene_skip_mode();
+
+    uint32_t get_enabled_cheats();
 
     void open_quit_game_prompt();
 };

--- a/patches/cheat_patches.c
+++ b/patches/cheat_patches.c
@@ -1,0 +1,87 @@
+#include "patches.h"
+#include "input.h"
+
+// @recomp Classic Cheats - proper recomp implementations of GameShark cheats.
+// Each cheat is toggled independently via the Enhancements settings tab.
+// The bitmask returned by recomp_get_enabled_cheats() has one bit per cheat.
+
+#define CHEAT_INFINITE_HEALTH        (1 << 0)
+#define CHEAT_INFINITE_LIVES         (1 << 1)
+#define CHEAT_INFINITE_AIR           (1 << 2)
+#define CHEAT_INFINITE_EGGS          (1 << 3)
+#define CHEAT_INFINITE_RED_FEATHERS  (1 << 4)
+#define CHEAT_INFINITE_GOLD_FEATHERS (1 << 5)
+#define CHEAT_INFINITE_MUMBO_TOKENS  (1 << 6)
+#define CHEAT_HOVER                  (1 << 7)
+
+// Item score array: D_80385F30[0x2C], indexed by enum item_e values.
+extern s32 D_80385F30[];
+
+s32 item_getCount(s32 item);
+void baphysics_set_vertical_velocity(f32);
+u32 bakey_held(s32 button_indx);
+
+// @recomp Called every frame from game_draw() to apply enabled classic cheats.
+// Each cheat writes max values directly into the item score array,
+// mirroring what the original GameShark codes did via raw memory writes.
+void apply_classic_cheats(void) {
+    u32 cheats = recomp_get_enabled_cheats();
+    if (cheats == 0) {
+        return;
+    }
+
+    // @recomp Infinite Health: set current health to max health.
+    // Only applies when health total is > 0 (i.e. player is in-game).
+    // GameShark: 803851A3 0008
+    if (cheats & CHEAT_INFINITE_HEALTH) {
+        s32 max_health = D_80385F30[ITEM_15_HEALTH_TOTAL];
+        if (max_health > 0) {
+            D_80385F30[ITEM_14_HEALTH] = max_health;
+        }
+    }
+
+    // @recomp Infinite Lives: keep lives at 9.
+    // GameShark: 80385F8B 00FF (we cap at 9 for HUD display correctness).
+    if (cheats & CHEAT_INFINITE_LIVES) {
+        D_80385F30[ITEM_16_LIFE] = 9;
+    }
+
+    // @recomp Infinite Air: keep air at maximum (3600 units = full meter).
+    // GameShark: 813851AE 0E10
+    if (cheats & CHEAT_INFINITE_AIR) {
+        D_80385F30[ITEM_17_AIR] = 3600;
+    }
+
+    // @recomp Infinite Eggs: keep egg count at 100.
+    // GameShark: 80385F67 00FF (we use the proper max of 100).
+    if (cheats & CHEAT_INFINITE_EGGS) {
+        D_80385F30[ITEM_D_EGGS] = 100;
+    }
+
+    // @recomp Infinite Red Feathers: keep count at 50.
+    // GameShark: 80385F6F 00FF (we use the proper max of 50).
+    if (cheats & CHEAT_INFINITE_RED_FEATHERS) {
+        D_80385F30[ITEM_F_RED_FEATHER] = 50;
+    }
+
+    // @recomp Infinite Gold Feathers: keep count at 10.
+    // GameShark: 80385F73 00FF (we use the proper max of 10).
+    if (cheats & CHEAT_INFINITE_GOLD_FEATHERS) {
+        D_80385F30[ITEM_10_GOLD_FEATHER] = 10;
+    }
+
+    // @recomp Infinite Mumbo Tokens: keep current level tokens at 99.
+    // GameShark: 80385FC6 00FF + 80385FA2 00FF
+    if (cheats & CHEAT_INFINITE_MUMBO_TOKENS) {
+        D_80385F30[ITEM_1C_MUMBO_TOKEN] = 99;
+    }
+
+    // @recomp Hover: hold L to levitate upward.
+    // Sets vertical velocity each frame while L is held, working with the
+    // physics system instead of fighting it. Releasing L lets gravity resume.
+    if (cheats & CHEAT_HOVER) {
+        if (bakey_held(BUTTON_L)) {
+            baphysics_set_vertical_velocity(600.0f);
+        }
+    }
+}

--- a/patches/graphics_patches.c
+++ b/patches/graphics_patches.c
@@ -46,6 +46,7 @@ extern u32 dynamic_camera_target_index;
 extern void recomp_reset_skinning_stack();
 extern void recomp_reset_map_model_skinning();
 extern void recomp_advance_dynamic_camera_targets();
+void apply_classic_cheats(void);
 
 // @recomp Patched to not free anything.
 RECOMP_PATCH void graphicsCache_release(void) {
@@ -100,6 +101,9 @@ RECOMP_PATCH void game_draw(s32 arg0){
 
     // @recomp Update note saving state.
     note_saving_update();
+
+    // @recomp Apply any enabled classic cheats.
+    apply_classic_cheats();
 
     // @recomp Track the original values.
     Mtx* mtx_start = mtx;

--- a/patches/input.h
+++ b/patches/input.h
@@ -27,5 +27,7 @@ DECLARE_FUNC(void, recomp_get_flying_and_swimming_inverted_axes, s32* x, s32* y)
 DECLARE_FUNC(void, recomp_get_first_person_inverted_axes, s32* x, s32* y);
 DECLARE_FUNC(void, recomp_get_right_analog_inputs, float* x, float* y);
 DECLARE_FUNC(void, recomp_set_right_analog_suppressed, s32 suppressed);
+DECLARE_FUNC(s32, recomp_check_cutscene_skip);
+DECLARE_FUNC(u32, recomp_get_enabled_cheats);
 
 #endif

--- a/patches/load_patches.c
+++ b/patches/load_patches.c
@@ -94,13 +94,15 @@ void hotpatch_intro_opa_map_model(BKModelBin* model_bin) {
 }
 
 void reset_cutscene_timings_state(void);
+void reset_cutscene_skip_state(void);
 
 // @recomp Patched to act as a point to run code when a new map is loaded.
 // This includes:
 //   * Resetting all extended marker data and skip interpolation for the next frame.
-//   * Hotpatching the map model for the title cutscene to fix ultrawide effects. 
+//   * Hotpatching the map model for the title cutscene to fix ultrawide effects.
 //   * Resetting the spawned static note count.
 //   * Resetting the variables used to keep track of correcting the intro cutscene timings
+//   * Resetting the cutscene skip state
 RECOMP_PATCH void func_803329AC(void){
     s32 i;
     
@@ -133,4 +135,7 @@ RECOMP_PATCH void func_803329AC(void){
 
     // @recomp Reset the intro cutscene timing corrections so the cutscene can be played again
     reset_cutscene_timings_state();
+
+    // @recomp Reset the cutscene skip state so it can be re-triggered on the next cutscene map
+    reset_cutscene_skip_state();
 }

--- a/patches/syms.ld
+++ b/patches/syms.ld
@@ -52,3 +52,5 @@ recomp_get_flying_and_swimming_inverted_axes = 0x8F0000BC;
 recomp_get_first_person_inverted_axes = 0x8F0000C0;
 recomp_get_analog_cam_sensitivity = 0x8F0000C4;
 recomp_run_ui_callbacks = 0x8F0000C8;
+recomp_check_cutscene_skip = 0x8F0000CC;
+recomp_get_enabled_cheats = 0x8F0000D0;

--- a/patches/title_screen_patches.c
+++ b/patches/title_screen_patches.c
@@ -1,6 +1,7 @@
 #include "patches.h"
 
 #include "enums.h"
+#include "input.h"
 
 struct Struct_core2_9B180_1;
 typedef struct Struct_core2_9B180_1 Struct_core2_9B180_1;
@@ -20,20 +21,140 @@ extern Struct_core2_9B180_0 D_8036DE00[];
 
 void func_80322318(Struct_core2_9B180_0*);
 int map_get(void);
+void transitionToMap(s32 map, s32 exit, s32 transition);
 
-// @recomp Patched to always allow skipping the intro sequence.
+// @recomp Returns true if the current map is a cutscene map that can be skipped.
+// NOTE: MAP_1F_CS_START_RAREWARE is intentionally excluded — the game's own
+// func_80322318 handler already manages logo skip to file select.
+static bool is_skippable_cutscene_map(void) {
+    switch (map_get()) {
+    case MAP_1E_CS_START_NINTENDO:
+    case MAP_7B_CS_INTRO_GL_DINGPOT_1:
+    case MAP_7C_CS_INTRO_BANJOS_HOUSE_1:
+    case MAP_7D_CS_SPIRAL_MOUNTAIN_1:
+    case MAP_7E_CS_SPIRAL_MOUNTAIN_2:
+    case MAP_81_CS_INTRO_GL_DINGPOT_2:
+    case MAP_82_CS_ENTERING_GL_MACHINE_ROOM:
+    case MAP_85_CS_SPIRAL_MOUNTAIN_3:
+    case MAP_86_CS_SPIRAL_MOUNTAIN_4:
+    case MAP_87_CS_SPIRAL_MOUNTAIN_5:
+    case MAP_88_CS_SPIRAL_MOUNTAIN_6:
+    case MAP_89_CS_INTRO_BANJOS_HOUSE_2:
+    case MAP_8A_CS_INTRO_BANJOS_HOUSE_3:
+    case MAP_94_CS_INTRO_SPIRAL_7:
+    case MAP_20_CS_END_NOT_100:
+    case MAP_95_CS_END_ALL_100:
+    case MAP_96_CS_END_BEACH_1:
+    case MAP_97_CS_END_BEACH_2:
+    case MAP_98_CS_END_SPIRAL_MOUNTAIN_1:
+    case MAP_99_CS_END_SPIRAL_MOUNTAIN_2:
+    // Exclude game-over cutscenes as skipping those could cause issues.
+    // case MAP_83_CS_GAME_OVER_MACHINE_ROOM:
+    // case MAP_84_CS_UNUSED_MACHINE_ROOM:
+        return TRUE;
+    default:
+        return FALSE;
+    }
+}
+
+// @recomp Returns the skip destination for the current cutscene map.
+// Uses transitionToMap() to directly load the target map.
+// Destinations are based on the decomp's actual game flow:
+//   Boot → Logo → File Select → New Game → Intro Cutscenes → Spiral Mountain
+//   End-game cutscenes → Logo → File Select
+// MAP_1F (Rareware logo) is NOT handled here — the game's own func_80322318
+// handler already manages that transition to file select.
+static bool try_skip_cutscene(int current_map) {
+    switch (current_map) {
+    // @recomp Nintendo logo: skip to Rareware logo.
+    case MAP_1E_CS_START_NINTENDO:
+        transitionToMap(MAP_1F_CS_START_RAREWARE, 0, 1);
+        return TRUE;
+
+    // @recomp Intro cutscenes: skip to Spiral Mountain.
+    // These ONLY play after starting a new game from file select, so a save
+    // file IS loaded. Exit 0x12 is the intro entry point (from decomp chain:
+    // MAP_89 → MAP_1 exit 0x12).
+    case MAP_7B_CS_INTRO_GL_DINGPOT_1:
+    case MAP_7C_CS_INTRO_BANJOS_HOUSE_1:
+    case MAP_7D_CS_SPIRAL_MOUNTAIN_1:
+    case MAP_7E_CS_SPIRAL_MOUNTAIN_2:
+    case MAP_81_CS_INTRO_GL_DINGPOT_2:
+    case MAP_82_CS_ENTERING_GL_MACHINE_ROOM:
+    case MAP_85_CS_SPIRAL_MOUNTAIN_3:
+    case MAP_86_CS_SPIRAL_MOUNTAIN_4:
+    case MAP_87_CS_SPIRAL_MOUNTAIN_5:
+    case MAP_88_CS_SPIRAL_MOUNTAIN_6:
+    case MAP_89_CS_INTRO_BANJOS_HOUSE_2:
+    case MAP_8A_CS_INTRO_BANJOS_HOUSE_3:
+    case MAP_94_CS_INTRO_SPIRAL_7:
+        transitionToMap(MAP_1_SM_SPIRAL_MOUNTAIN, 0x12, 1);
+        return TRUE;
+
+    // @recomp End-game cutscenes: skip to file select.
+    // The game's own flow goes: end cutscenes → Rareware logo → file select.
+    // We skip the logo step for cleaner UX.
+    case MAP_20_CS_END_NOT_100:
+    case MAP_95_CS_END_ALL_100:
+    case MAP_96_CS_END_BEACH_1:
+    case MAP_97_CS_END_BEACH_2:
+    case MAP_98_CS_END_SPIRAL_MOUNTAIN_1:
+    case MAP_99_CS_END_SPIRAL_MOUNTAIN_2:
+        transitionToMap(MAP_91_FILE_SELECT, 0, 1);
+        return TRUE;
+
+    default:
+        return FALSE;
+    }
+}
+
+// @recomp State tracking for cutscene skip.
+static int cutscene_skip_last_map = -1;
+static int cutscene_skip_frame_counter = 0;
+
+// @recomp Called on map load to reset the cutscene skip state.
+void reset_cutscene_skip_state(void) {
+    cutscene_skip_frame_counter = 0;
+}
+
+// @recomp Patched to allow skipping the intro sequence and all cutscenes when the setting is enabled.
 RECOMP_PATCH void func_80322490(void) {
     Struct_core2_9B180_0 *i_ptr;
     static int introFrameCounter = 0;
 
     introFrameCounter++;
 
+    // @recomp Reset cutscene skip frame counter when the map changes.
+    int current_map = map_get();
+    if (current_map != cutscene_skip_last_map) {
+        cutscene_skip_frame_counter = 0;
+        cutscene_skip_last_map = current_map;
+    }
+
+    cutscene_skip_frame_counter++;
+
+    // @recomp When Start is pressed on a skippable cutscene, use transitionToMap()
+    // to directly load the skip destination. This avoids the broken fast-forward
+    // approach that forced all actor callbacks and caused invalid game state.
+    if (is_skippable_cutscene_map() && cutscene_skip_frame_counter > 30) {
+        if (recomp_check_cutscene_skip()) {
+            if (try_skip_cutscene(current_map)) {
+                return;
+            }
+        }
+    }
+
     if (D_80383330 != 0) {
         for(i_ptr = D_8036DE00; i_ptr != &D_8036DE00[6]; i_ptr++){
-            // @recomp Always allow skipping thex intro sequence, with a delay of 1 second to prevent
+            bool should_run = (i_ptr->unk4 != 0);
+
+            // @recomp Always allow skipping the intro sequence, with a delay of 1 second to prevent
             // issues with accidentally skipping the intro when navigating the launcher with a controller.
-            if((i_ptr->unk4 != 0 || (i_ptr->unkC == func_80322318 && map_get() == MAP_1F_CS_START_RAREWARE && introFrameCounter > 30)) 
-            && i_ptr->unkC != NULL){
+            if (i_ptr->unkC == func_80322318 && current_map == MAP_1F_CS_START_RAREWARE && introFrameCounter > 30) {
+                should_run = TRUE;
+            }
+
+            if(should_run && i_ptr->unkC != NULL){
                 i_ptr->unkC(i_ptr);
             }
         }

--- a/src/game/config.cpp
+++ b/src/game/config.cpp
@@ -171,7 +171,72 @@ static void add_graphics_options(recomp::config::Config &config) {
         "Sets the aspect ratio limit for cutscenes. Cutscenes have been adjusted to work in <recomp-color primary>16:9</recomp-color>, which is the default option. Wider aspect ratios may show details that weren't meant to be on-screen.",
         cutscene_aspect_ratio_mode_options,
         banjo::CutsceneAspectRatioMode::Clamp16x9
-    );    
+    );
+}
+
+static void add_enhancements_options(recomp::config::Config &config) {
+    using EnumOptionVector = const std::vector<recomp::config::ConfigOptionEnumOption>;
+    static EnumOptionVector cutscene_skip_mode_options = {
+        {banjo::CutsceneSkipMode::Off, "Off", "Off"},
+        {banjo::CutsceneSkipMode::On, "On", "On"},
+    };
+    config.add_enum_option(
+        banjo::configkeys::enhancements::cutscene_skip_mode,
+        "Cutscene Skip",
+        "When enabled, press <recomp-color primary>Start</recomp-color> during cutscenes to skip them.",
+        cutscene_skip_mode_options,
+        banjo::CutsceneSkipMode::Off
+    );
+
+    // Classic Cheats
+    config.add_bool_option(
+        banjo::configkeys::enhancements::cheat_infinite_health,
+        "Infinite Health",
+        "Keeps Banjo's health at maximum at all times.",
+        false
+    );
+    config.add_bool_option(
+        banjo::configkeys::enhancements::cheat_infinite_lives,
+        "Infinite Lives",
+        "Keeps Banjo's extra lives at 9.",
+        false
+    );
+    config.add_bool_option(
+        banjo::configkeys::enhancements::cheat_infinite_air,
+        "Infinite Air",
+        "Prevents the air meter from decreasing while underwater.",
+        false
+    );
+    config.add_bool_option(
+        banjo::configkeys::enhancements::cheat_infinite_eggs,
+        "Infinite Eggs",
+        "Keeps Banjo's egg count at the maximum of 100.",
+        false
+    );
+    config.add_bool_option(
+        banjo::configkeys::enhancements::cheat_infinite_red_feathers,
+        "Infinite Red Feathers",
+        "Keeps Banjo's red feather count at the maximum of 50.",
+        false
+    );
+    config.add_bool_option(
+        banjo::configkeys::enhancements::cheat_infinite_gold_feathers,
+        "Infinite Gold Feathers",
+        "Keeps Banjo's gold feather count at the maximum of 10.",
+        false
+    );
+    config.add_bool_option(
+        banjo::configkeys::enhancements::cheat_infinite_mumbo_tokens,
+        "Infinite Mumbo Tokens",
+        "Keeps Banjo's Mumbo Token count at 99.",
+        false
+    );
+    config.add_bool_option(
+        banjo::configkeys::enhancements::cheat_hover,
+        "Hover",
+        "Hold <recomp-color primary>L</recomp-color> to levitate upward. Release to fall back down.",
+        false
+    );
 }
 
 static void set_control_defaults() {
@@ -242,6 +307,34 @@ banjo::CutsceneAspectRatioMode banjo::get_cutscene_aspect_ratio_mode() {
     return get_graphics_config_enum_value<banjo::CutsceneAspectRatioMode>(banjo::configkeys::graphics::cutscene_aspect_ratio_mode);
 }
 
+static const std::string enhancements_tab_id = "enhancements";
+
+template <typename T = uint32_t>
+T get_enhancements_config_enum_value(const std::string& option_id) {
+    return static_cast<T>(std::get<uint32_t>(recompui::config::get_config(enhancements_tab_id).get_option_value(option_id)));
+}
+
+banjo::CutsceneSkipMode banjo::get_cutscene_skip_mode() {
+    return get_enhancements_config_enum_value<banjo::CutsceneSkipMode>(banjo::configkeys::enhancements::cutscene_skip_mode);
+}
+
+static bool get_enhancements_config_bool_value(const std::string& option_id) {
+    return std::get<bool>(recompui::config::get_config(enhancements_tab_id).get_option_value(option_id));
+}
+
+uint32_t banjo::get_enabled_cheats() {
+    uint32_t flags = 0;
+    if (get_enhancements_config_bool_value(banjo::configkeys::enhancements::cheat_infinite_health))        flags |= (1 << 0);
+    if (get_enhancements_config_bool_value(banjo::configkeys::enhancements::cheat_infinite_lives))         flags |= (1 << 1);
+    if (get_enhancements_config_bool_value(banjo::configkeys::enhancements::cheat_infinite_air))           flags |= (1 << 2);
+    if (get_enhancements_config_bool_value(banjo::configkeys::enhancements::cheat_infinite_eggs))          flags |= (1 << 3);
+    if (get_enhancements_config_bool_value(banjo::configkeys::enhancements::cheat_infinite_red_feathers))  flags |= (1 << 4);
+    if (get_enhancements_config_bool_value(banjo::configkeys::enhancements::cheat_infinite_gold_feathers)) flags |= (1 << 5);
+    if (get_enhancements_config_bool_value(banjo::configkeys::enhancements::cheat_infinite_mumbo_tokens))  flags |= (1 << 6);
+    if (get_enhancements_config_bool_value(banjo::configkeys::enhancements::cheat_hover))                flags |= (1 << 7);
+    return flags;
+}
+
 void banjo::init_config() {
     std::filesystem::path recomp_dir = recompui::file::get_app_folder_path();
 
@@ -259,6 +352,9 @@ void banjo::init_config() {
 
     auto &graphics_config = recompui::config::create_graphics_tab();
     add_graphics_options(graphics_config);
+
+    auto &enhancements_config = recompui::config::create_config_tab("Enhancements", enhancements_tab_id, false);
+    add_enhancements_options(enhancements_config);
 
     set_control_defaults();
     set_control_descriptions();


### PR DESCRIPTION
## Summary

adds a new enhancements tab to settings with cutscene skip and classic cheats.

**cutscene skip** lets you press start during cutscenes to skip them. intro cutscenes (only play after new game from file select) skip to spiral mountain. end game cutscenes skip to file select. the rareware logo uses the games own skip handler so we dont touch it.

**classic cheats** are proper recomp implementations of the old gameshark cheats. infinite health, lives, air, eggs, red feathers, gold feathers, mumbo tokens. theres also a hover cheat that lets you hold L to levitate using baphysics_set_vertical_velocity so it works with the physics system instead of fighting gravity.

all cheats are individually togglable from the enhancements tab. the cheat bitmask is passed to mips patches via a single recomp_get_enabled_cheats() call per frame.

## Test plan
- [x] boot game, press start on rareware logo, confirm it goes to file select (games own handler)
- [x] start new game, skip intro cutscenes with start, confirm it lands in spiral mountain
- [x] beat the game, skip ending cutscenes, confirm it goes to file select
- [x] toggle each cheat individually and verify it works in game
- [x] enable hover cheat, hold L, confirm banjo rises smoothly and falls when released
- [x] verify cheats dont break normal gameplay when disabled