### PR TITLE
build: some macOS fixes

### DIFF
--- a/.github/macos/ld64
+++ b/.github/macos/ld64
@@ -19,6 +19,9 @@ will have their max_prot values properly preserved in the output binary.
 
 import sys
 import subprocess
+
+sys.path.append(subprocess.run(["find", "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework", "-type", "d", "-name", "site-packages"], capture_output=True, text=True).stdout.strip())
+
 from itertools import takewhile
 from macholib import MachO, ptypes
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,20 @@ if (APPLE)
     set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "Minimum OS X deployment version")
 endif()
 
+# Use ccache if available and not already enabled on the command line.
+# This has to be done before the project() call.
+if(NOT CMAKE_CXX_COMPILER_LAUNCHER)
+    find_program(CCACHE_EXECUTABLE ccache)
+    if(CCACHE_EXECUTABLE)
+        message(STATUS "Enabling ccache")
+
+        set(CMAKE_C_COMPILER_LAUNCHER      ${CCACHE_EXECUTABLE} CACHE STRING "C compiler launcher"             FORCE)
+        set(CMAKE_CXX_COMPILER_LAUNCHER    ${CCACHE_EXECUTABLE} CACHE STRING "C++ compiler launcher"           FORCE)
+        set(CMAKE_OBJC_COMPILER_LAUNCHER   ${CCACHE_EXECUTABLE} CACHE STRING "Objective C compiler launcher"   FORCE)
+        set(CMAKE_OBJCXX_COMPILER_LAUNCHER ${CCACHE_EXECUTABLE} CACHE STRING "Objective C++ compiler launcher" FORCE)
+    endif()
+endif()
+
 project(BanjoRecompiled LANGUAGES C CXX)
 set(CMAKE_C_STANDARD 17)
 set(CMAKE_CXX_STANDARD 20)
@@ -39,6 +53,15 @@ set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 if (WIN32)
     set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/lib/")
+endif()
+
+if(APPLE)
+    if(EXISTS "/opt/homebrew/opt/zlib")
+        list(APPEND CMAKE_PREFIX_PATH "/opt/homebrew/opt/zlib")
+    elseif(EXISTS "/usr/local/opt/zlib")
+        list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/zlib")
+    endif()
+    set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH}" CACHE STRING "CMake prefix path" FORCE)
 endif()
 
 set(RT64_STATIC TRUE)
@@ -370,3 +393,8 @@ target_sources(BanjoRecompiled PRIVATE ${GENERATED_NRM_SOURCES})
 target_sources(BanjoRecompiled PRIVATE ${SOURCES})
 
 set_property(TARGET BanjoRecompiled PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+
+if(APPLE)
+    set(CMAKE_OBJC_FLAGS   "${CMAKE_OBJC_FLAGS}   -Wno-error -Wno-error=unguarded-availability-new" CACHE STRING "Objective C compiler flags"   FORCE)
+    set(CMAKE_OBJCXX_FLAGS "${CMAKE_OBJCXX_FLAGS} -Wno-error -Wno-error=unguarded-availability-new" CACHE STRING "Objective C++ compiler flags" FORCE)
+endif()


### PR DESCRIPTION
Add the Python module path for the macOS `ld64` wrapper script so that it can find the `macholib` module, because it sometimes fails to find it.

Add `-Wno-error=unguarded-availability-new` to Objective C and Objective C++ flags, this is necessary for some Clang toolchains like the Nix one with the SDK headers.

<!--- section:artifacts:start -->
### Build Artifacts
- [BanjoRecompiled-Linux-ARM64-Release.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5522205412.zip)
- [BanjoRecompiled-Linux-X64-Debug.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5522206221.zip)
- [BanjoRecompiled-Linux-ARM64-Debug.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5522209771.zip)
- [BanjoRecompiled-Linux-X64-Release.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5522211150.zip)
- [BanjoRecompiled-macOS-Release.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5522221101.zip)
- [BanjoRecompiled-macOS-Debug.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5522234434.zip)
- [BanjoRecompiled-Windows-Debug.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5522251798.zip)
- [BanjoRecompiled-Windows-RelWithDebInfo.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5522252628.zip)
- [BanjoRecompiled-PDB-Debug.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5522252682.zip)
- [BanjoRecompiled-PDB-RelWithDebInfo.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5522253439.zip)
- [BanjoRecompiled-Flatpak-X64-Debug.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5522298565.zip)
- [BanjoRecompiled-Flatpak-X64-Release.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5522301370.zip)
<!--- section:artifacts:end -->