### PR TITLE
macOS: fix SDL memory leak on destruction

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -156,6 +156,9 @@ bool SetImageAsIcon(const char* filename, SDL_Window* window)
 #endif
 
 SDL_Window* window;
+#if defined(__APPLE__)
+SDL_MetalView metal_view = nullptr;
+#endif
 
 ultramodern::renderer::WindowHandle create_window(ultramodern::gfx_callbacks_t::gfx_data_t) {
     uint32_t flags = SDL_WINDOW_RESIZABLE;
@@ -190,8 +193,8 @@ ultramodern::renderer::WindowHandle create_window(ultramodern::gfx_callbacks_t::
 #elif defined(__linux__) || defined(__ANDROID__)
     return ultramodern::renderer::WindowHandle{ window };
 #elif defined(__APPLE__)
-    SDL_MetalView view = SDL_Metal_CreateView(window);
-    return ultramodern::renderer::WindowHandle{ wmInfo.info.cocoa.window,  SDL_Metal_GetLayer(view) };
+    metal_view = SDL_Metal_CreateView(window);
+    return ultramodern::renderer::WindowHandle{ wmInfo.info.cocoa.window,  SDL_Metal_GetLayer(metal_view) };
 #else
     static_assert(false && "Unimplemented");
 #endif
@@ -821,6 +824,22 @@ int main(int argc, char** argv) {
     if (preloaded) {
         release_preload(preload_context);
     }
+
+#if defined(__APPLE__)
+    // Destroy the Metal view before destroying the window
+    if (metal_view != nullptr) {
+        SDL_Metal_DestroyView(metal_view);
+        metal_view = nullptr;
+    }
+#endif
+
+    // Cleanup SDL resources
+    if (window != nullptr) {
+        SDL_DestroyWindow(window);
+        window = nullptr;
+    }
+
+    SDL_Quit();
 
 #ifdef _WIN32
     // End high resolution timing period.


### PR DESCRIPTION
Destroy the Metal view and main window on destruction to prevent a memory leak.

<!--- section:artifacts:start -->
### Build Artifacts
- [BanjoRecompiled-Linux-X64-Debug.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5526656818.zip)
- [BanjoRecompiled-Linux-ARM64-Release.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5526660167.zip)
- [BanjoRecompiled-Linux-X64-Release.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5526665461.zip)
- [BanjoRecompiled-Linux-ARM64-Debug.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5526666008.zip)
- [BanjoRecompiled-macOS-Release.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5526678617.zip)
- [BanjoRecompiled-macOS-Debug.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5526686683.zip)
- [BanjoRecompiled-Windows-Debug.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5526687249.zip)
- [BanjoRecompiled-PDB-Debug.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5526688106.zip)
- [BanjoRecompiled-Windows-RelWithDebInfo.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5526695404.zip)
- [BanjoRecompiled-PDB-RelWithDebInfo.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5526696121.zip)
- [BanjoRecompiled-Flatpak-X64-Debug.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5526786652.zip)
- [BanjoRecompiled-Flatpak-X64-Release.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/5526795453.zip)
<!--- section:artifacts:end -->