### PR TITLE
Grant access to Gamescope socket for Steam Deck OLED

### DIFF
--- a/flatpak/io.github.banjorecomp.banjorecomp.json
+++ b/flatpak/io.github.banjorecomp.banjorecomp.json
@@ -13,7 +13,8 @@
     "--filesystem=host",
     "--filesystem=/media",
     "--filesystem=/run/media",
-    "--filesystem=/mnt"
+    "--filesystem=/mnt",
+    "--filesystem=xdg-run/gamescope-0:ro"
   ],
   "modules": [
     {


### PR DESCRIPTION
* See https://github.com/flathub/org.DolphinEmu.dolphin-emu/pull/178#issuecomment-1905194043 for more information
* Bug only occurs on the Steam Deck OLED.

To replicate the error, on a Steam Deck OLED, install the Flatpak, launch the recomp in Game Mode, see error. Gamescope Flatpak is primarily used for HDR in other Flatpaks (Dolphin, PrimeHack, Heroic, etc.).

![image](https://github.com/user-attachments/assets/745b9487-b8ed-4d3f-bb55-6e02c152ba92)

<!--- section:artifacts:start -->
### Build Artifacts
- [BanjoRecompiled-macOS-Release.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/6083926450.zip)
- [BanjoRecompiled-macOS-Debug.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/6083746266.zip)
- [BanjoRecompiled-Linux-X64-Release.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/6083040122.zip)
- [BanjoRecompiled-Flatpak-X64-Release.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/6083024045.zip)
- [BanjoRecompiled-Flatpak-X64-Debug.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/6083016521.zip)
- [BanjoRecompiled-PDB-RelWithDebInfo.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/6083007867.zip)
- [BanjoRecompiled-Windows-RelWithDebInfo.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/6083006674.zip)
- [BanjoRecompiled-PDB-Debug.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/6082994522.zip)
- [BanjoRecompiled-Windows-Debug.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/6082993177.zip)
- [BanjoRecompiled-Linux-X64-Debug.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/6082980106.zip)
- [BanjoRecompiled-Linux-ARM64-Release.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/6082921624.zip)
- [BanjoRecompiled-Linux-ARM64-Debug.zip](https://nightly.link/BanjoRecomp/BanjoRecomp/actions/artifacts/6082913671.zip)
<!--- section:artifacts:end -->