### PR TITLE
Reset camera target when player exits climbing state with analog camera held.

### DIFF
--- a/patches/camera_and_axis_inversion_patches.c
+++ b/patches/camera_and_axis_inversion_patches.c
@@ -580,6 +580,11 @@ RECOMP_PATCH void func_80291154(void) {
             ncDynamicCamera_setState(DYNAMIC_CAMERA_STATE_R_LOOK);
             func_80291488(0x4);
             func_80290F14();
+
+            // The camera target must be reinitialized when the player exits the pole climbing state so the target doesn't stay on the climbable object.
+            if ((D_8037DB40 == 3) && (player_movementGroup() != BSGROUP_5_CLIMB)) {
+                func_802C0150(2);
+            }
         }
         else {
             tmp = func_8029105C(7);


### PR DESCRIPTION
Fixes https://github.com/BanjoRecomp/BanjoRecomp/issues/243.